### PR TITLE
Refactoring GetRuns, and testing dataController

### DIFF
--- a/__tests__/csvReadingTiming.test.js
+++ b/__tests__/csvReadingTiming.test.js
@@ -1,0 +1,54 @@
+/**
+ * This file tests how long it takes to read from a pre-determined data.csv file.
+ * The purpose of this test is to determine a baseline server time necessary to read
+ * all lines in a given file, and determine the limit of optimization in other parts
+ * of the application's functionality
+ */
+
+const fs = require('fs');
+const path = require('path');
+const parse = require('csv-parser');
+
+
+
+const readCSVFile = async (fileName) => {
+  return new Promise((resolve, reject) => {
+    const results = [];
+    fs.createReadStream(fileName)
+      .pipe(parse())
+      .on('data', (data) => results.push(data))
+      .on('end', () => {
+        resolve(results);
+      });
+  });
+};
+
+
+
+const timeRuns = async () => {
+  let timingResults = [];
+
+    for (let i = 0; i < 20; i++) {
+      let startTime = Date.now();
+
+      await readCSVFile(path.resolve(__dirname, `../server/storage/data.csv`));
+
+      let endTime = Date.now();
+      timingResults.push(endTime - startTime);
+    }
+
+  return timingResults;
+}
+
+
+describe('Test the average time to read data.csv', () => {
+  it('Should be able to read ~200k rows in <350ms', async () => {
+    const timingArray = await timeRuns();
+
+    const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
+    console.log('Timing results of readingCSV is: ', timingArray);
+    console.log('Average time of  readingCSV is: ', average);
+    expect(average).toBeLessThan(350);
+  }, 100000)
+
+});

--- a/__tests__/csvReadingTiming.test.js
+++ b/__tests__/csvReadingTiming.test.js
@@ -46,8 +46,6 @@ describe('Test the average time to read data.csv', () => {
     const timingArray = await timeRuns();
 
     const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
-    console.log('Timing results of readingCSV is: ', timingArray);
-    console.log('Average time of  readingCSV is: ', average);
     expect(average).toBeLessThan(350);
   }, 100000)
 

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -1,0 +1,16 @@
+const dataController = require('../server/controllers/dataController');
+
+/**
+ * Testing getRuns
+ * 
+ */
+
+describe('Data Controller: getRuns', () => {
+
+  // get an array of all functions (records) from res.locals
+
+  // get All Rows from a dataFile each object is a row with a key== column name and value = value in cell
+
+
+
+});

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -1,6 +1,4 @@
 const dataController = require('../server/controllers/dataController');
-import mockCsvFuncs from '../server/controllers/csvFuncs';
-
 
 // We want to mock the csvFuncs controller
 jest.mock('../server/controllers/csvFuncs');
@@ -58,16 +56,17 @@ describe('Data Controller: getRuns Unit Testing', () => {
     next = jest.fn();
   });
 
-  xit('Should should call next one time.', () => {
+  it('Should should call next one time.', () => {
     dataController.getRuns(req, res, next);
 
     expect(next.mock.calls.length).toEqual(1);
   });
 
-  it('Should set res.locals.all to the result of csvFUncs.getAllRows().', async () => {
+  it('Should set res.locals.all to the result of csvFuncs.getAllRows().', async () => {
     console.log('inside second test. Beginning res object is: ', res);
     await dataController.getRuns(req, res, next);
     console.log('inside second test. Ending res object is: ', res);
+    console.log('inside second test. Ending res.locals.runs object is: ', res.locals.runs);
     console.log('Function checks res.locals.all at ', Date.now());
     expect(res.locals.all.length).toBe(3);
   });

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -1,16 +1,74 @@
 const dataController = require('../server/controllers/dataController');
+import mockCsvFuncs from '../server/controllers/csvFuncs';
+
+
+// We want to mock the csvFuncs controller
+jest.mock('../server/controllers/csvFuncs');
 
 /**
- * Testing getRuns
- * 
+ * Testing getRuns within the dataController
+ *
  */
-
-describe('Data Controller: getRuns', () => {
-
+describe('Data Controller: getRuns Unit Testing', () => {
   // get an array of all functions (records) from res.locals
 
   // get All Rows from a dataFile each object is a row with a key== column name and value = value in cell
 
+  let req = {};
+  let res = { locals: { records: [], runs: [], all: [] } };
+  let next;
 
+  /**
+   * Reset req, res, and next before each test to validate they are passed in as unit tests
+   */
+  beforeEach(() => {
+    // Mock data from dataController.getData() with three records
+    res.locals.records = [
+      {
+        funcID: '1',
+        appName: 'Mock App',
+        funcName: 'MockFunc1',
+        funcFreq: '10S',
+        userID: 'abc123',
+        warmerOn: 'Yes',
+      },
+      {
+        funcID: '2',
+        appName: 'Mock App',
+        funcName: 'MockFunc2',
+        funcFreq: '1M',
+        userID: 'abc123',
+        warmerOn: 'Yes',
+      },
+      {
+        funcID: '3',
+        appName: 'Mock App',
+        funcName: 'MockFunc3',
+        funcFreq: '5M',
+        userID: 'abc123',
+        warmerOn: 'No',
+      },
+    ];
 
+    res.locals.runs = [];
+
+    res.locals.all = [];
+
+    // Mock function so we can validate next has been called
+    next = jest.fn();
+  });
+
+  xit('Should should call next one time.', () => {
+    dataController.getRuns(req, res, next);
+
+    expect(next.mock.calls.length).toEqual(1);
+  });
+
+  it('Should set res.locals.all to the result of csvFUncs.getAllRows().', async () => {
+    console.log('inside second test. Beginning res object is: ', res);
+    await dataController.getRuns(req, res, next);
+    console.log('inside second test. Ending res object is: ', res);
+    console.log('Function checks res.locals.all at ', Date.now());
+    expect(res.locals.all.length).toBe(3);
+  });
 });

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -56,18 +56,18 @@ describe('Data Controller: getRuns Unit Testing', () => {
     next = jest.fn();
   });
 
-  it('Should should call next one time.', () => {
-    dataController.getRuns(req, res, next);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    expect(next.mock.calls.length).toEqual(1);
+  it('Should should call next one time.', async () => {
+    await dataController.getRuns(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('Should set res.locals.all to the result of csvFuncs.getAllRows().', async () => {
-    console.log('inside second test. Beginning res object is: ', res);
     await dataController.getRuns(req, res, next);
-    console.log('inside second test. Ending res object is: ', res);
-    console.log('inside second test. Ending res.locals.runs object is: ', res.locals.runs);
-    console.log('Function checks res.locals.all at ', Date.now());
     expect(res.locals.all.length).toBe(3);
   });
 });

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -7,7 +7,7 @@ jest.mock('../server/controllers/csvFuncs');
  * Testing getRuns within the dataController
  *
  */
-describe('Data Controller: getRuns Unit Testing', () => {
+describe('Data Controller: getRuns Unit Tests', () => {
   // get an array of all functions (records) from res.locals
 
   // get All Rows from a dataFile each object is a row with a key== column name and value = value in cell
@@ -60,14 +60,31 @@ describe('Data Controller: getRuns Unit Testing', () => {
     jest.clearAllMocks();
   });
 
+
+  it('Should set res.locals.all to the result of csvFuncs.getAllRows() and next() to be called once.', async () => {
+    await dataController.getRuns(req, res, next);
+    // Result is mocked in server/controllers/__mocks__/csvFuncs.js
+    expect(res.locals.all).toEqual([1, 2, 3]);
+  });
+
   it('Should should call next one time.', async () => {
     await dataController.getRuns(req, res, next);
 
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it('Should set res.locals.all to the result of csvFuncs.getAllRows().', async () => {
+  it('Should have the name records in res.locals.runs as in res.locals.records', async () => {
     await dataController.getRuns(req, res, next);
-    expect(res.locals.all.length).toBe(3);
+    const resultingCalcs = res.locals.runs;
+    // Same length as input records
+    expect(res.locals.runs.length).toBe(3);
+
+    // Element has at least one of the three combos manually included but not any more
+    const includesInput = (current) => {
+      return (current.id === '1' && current.name === 'MockFunc1') ||
+        (current.id === '2' && current.name === 'MockFunc2') ||
+        (current.id === '3' && current.name === 'MockFunc3');
+    };
+    expect(res.locals.runs.every(includesInput)).toBe(true);
   });
 });

--- a/__tests__/dataController.test.js
+++ b/__tests__/dataController.test.js
@@ -1,3 +1,8 @@
+/**
+ * This file is repsonsible for unit testing functiosn in the dataController.
+ * It relies upon mocking functions that this relies upon (i.e. csvFuncs).
+ */
+
 const dataController = require('../server/controllers/dataController');
 
 // We want to mock the csvFuncs controller
@@ -60,7 +65,6 @@ describe('Data Controller: getRuns Unit Tests', () => {
     jest.clearAllMocks();
   });
 
-
   it('Should set res.locals.all to the result of csvFuncs.getAllRows() and next() to be called once.', async () => {
     await dataController.getRuns(req, res, next);
     // Result is mocked in server/controllers/__mocks__/csvFuncs.js
@@ -81,9 +85,11 @@ describe('Data Controller: getRuns Unit Tests', () => {
 
     // Element has at least one of the three combos manually included but not any more
     const includesInput = (current) => {
-      return (current.id === '1' && current.name === 'MockFunc1') ||
+      return (
+        (current.id === '1' && current.name === 'MockFunc1') ||
         (current.id === '2' && current.name === 'MockFunc2') ||
-        (current.id === '3' && current.name === 'MockFunc3');
+        (current.id === '3' && current.name === 'MockFunc3')
+      );
     };
     expect(res.locals.runs.every(includesInput)).toBe(true);
   });

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -5,15 +5,16 @@
  *
  */
 
+const request = require('supertest');
+const app = require('../server/server');
 
 /**
  * Helper function that runs the actual fetch request.
  * @returns data response object from fetching /api/data
  */
 const runTest = async () => {
-  const response = await fetch('http://localhost:3000/api/data');
-  const data = await response.json();
-  return data[0];
+  const response = await request(app).get('/api/data');
+  return response.body[0];
 };
 
 /**

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -1,0 +1,38 @@
+const runTest = async () => {
+  const response = await fetch('http://localhost:3000/api/data');
+  const data = await response.json();
+  return data[0];
+};
+
+const timeRuns = async () => {
+  // delcare an empty array of timing
+  let timingResults = [];
+
+  // on a loop, call runTest with timing, and push result to array
+  for(let i = 0; i < 20; i++) {
+    let startTime = Date.now();
+    await runTest();
+    let endTime = Date.now();
+    timingResults.push(endTime - startTime);
+  }
+
+  // return array of timing
+  return timingResults;
+}
+
+describe('Test to time responses to dataController.getRuns()', () => {
+
+  it('Should be able to run a request to api/data ', async () => {
+    const result = await runTest();
+    expect(Array.isArray(result)).toBe(true);
+  })
+
+  it('Should have an average timing less than 10,000ms', async () => {
+    const timingArray = await timeRuns();
+    const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
+    console.log('Timing results is: ', timingArray);
+    console.log('Average time is: ', average);
+    expect(average).toBeLessThan(10000);
+  }, 100000)
+
+});

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -1,15 +1,30 @@
+/**
+ * This file tests the timing of running a request to /api/data. Note that the server needs to be running, and there is a long-running test that can be skipped if desired.
+ * In order to run properly, this file needs to be ran while the server is live.
+ *
+ */
+
+
+/**
+ * Helper function that runs the actual fetch request.
+ * @returns data response object from fetching /api/data
+ */
 const runTest = async () => {
   const response = await fetch('http://localhost:3000/api/data');
   const data = await response.json();
   return data[0];
 };
 
+/**
+ * 
+ * @returns an array of recorded times for completing the runTest function
+ */
 const timeRuns = async () => {
   // delcare an empty array of timing
   let timingResults = [];
 
   // on a loop, call runTest with timing, and push result to array
-  for(let i = 0; i < 20; i++) {
+  for (let i = 0; i < 20; i++) {
     let startTime = Date.now();
     await runTest();
     let endTime = Date.now();
@@ -18,14 +33,13 @@ const timeRuns = async () => {
 
   // return array of timing
   return timingResults;
-}
+};
 
 describe('Test to time responses to dataController.getRuns()', () => {
-
   it('Should be able to run a request to api/data ', async () => {
     const result = await runTest();
     expect(Array.isArray(result)).toBe(true);
-  })
+  });
 
   it('Should have an average timing less than 10,000ms', async () => {
     const timingArray = await timeRuns();
@@ -33,6 +47,5 @@ describe('Test to time responses to dataController.getRuns()', () => {
     console.log('Timing results is: ', timingArray);
     console.log('Average time is: ', average);
     expect(average).toBeLessThan(10000);
-  }, 100000)
-
+  }, 100000);
 });

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -1,5 +1,6 @@
 /**
- * This file tests the timing of running a request to /api/data. Note that the server needs to be running, and there is a long-running test that can be skipped if desired.
+ * This file tests the timing of running a request to /api/data. Note that the server 
+ * needs to be running, and there is a long-running test that can be skipped if desired.
  * In order to run properly, this file needs to be ran while the server is live.
  *
  */
@@ -41,11 +42,11 @@ describe('Test to time responses to dataController.getRuns()', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 
-  it('Should have an average timing less than 1,000ms', async () => {
+  it('Should have an average timing less than 500ms', async () => {
     const timingArray = await timeRuns();
     const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
-    console.log('Timing results is: ', timingArray);
-    console.log('Average time is: ', average);
-    expect(average).toBeLessThan(1000);
+    console.log('Timing results of getRuns is: ', timingArray);
+    console.log('Average time of getRuns is: ', average);
+    expect(average).toBeLessThan(500);
   }, 100000);
 });

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -7,6 +7,7 @@
 
 const request = require('supertest');
 const app = require('../server/server');
+const server = require('../server/server');
 
 /**
  * Helper function that runs the actual fetch request.
@@ -38,6 +39,10 @@ const timeRuns = async () => {
 };
 
 describe('Test to time responses to dataController.getRuns()', () => {
+
+  afterAll(() => server.close());
+
+
   it('Should be able to run a request to api/data ', async () => {
     const result = await runTest();
     expect(Array.isArray(result)).toBe(true);

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -41,11 +41,11 @@ describe('Test to time responses to dataController.getRuns()', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 
-  it('Should have an average timing less than 10,000ms', async () => {
+  it('Should have an average timing less than 1,000ms', async () => {
     const timingArray = await timeRuns();
     const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
     console.log('Timing results is: ', timingArray);
     console.log('Average time is: ', average);
-    expect(average).toBeLessThan(10000);
+    expect(average).toBeLessThan(1000);
   }, 100000);
 });

--- a/__tests__/dataControllerTiming.test.js
+++ b/__tests__/dataControllerTiming.test.js
@@ -45,8 +45,6 @@ describe('Test to time responses to dataController.getRuns()', () => {
   it('Should have an average timing less than 500ms', async () => {
     const timingArray = await timeRuns();
     const average = timingArray.reduce((a, b) => a + b) / timingArray.length;
-    console.log('Timing results of getRuns is: ', timingArray);
-    console.log('Average time of getRuns is: ', average);
     expect(average).toBeLessThan(500);
   }, 100000);
 });

--- a/__tests__/sum.test.js
+++ b/__tests__/sum.test.js
@@ -1,5 +1,0 @@
-const sum = require('../src/sum');
-
-test('adds 1 + 2 = 3', () => {
-  expect(sum(1, 2)).toBe(3);
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "sass": "^1.71.1",
         "sass-loader": "^14.1.1",
         "style-loader": "^3.3.4",
+        "supertest": "^6.3.4",
         "svg-inline-loader": "^0.8.2",
         "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4",
@@ -4518,6 +4519,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5289,6 +5296,15 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -5394,6 +5410,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/core-js-compat": {
@@ -6048,6 +6070,16 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -6984,6 +7016,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -7247,6 +7285,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -7576,6 +7629,15 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/history": {
@@ -13345,6 +13407,85 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "sass": "^1.71.1",
     "sass-loader": "^14.1.1",
     "style-loader": "^3.3.4",
+    "supertest": "^6.3.4",
     "svg-inline-loader": "^0.8.2",
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4",

--- a/server/controllers/__mocks__/csvFuncs.js
+++ b/server/controllers/__mocks__/csvFuncs.js
@@ -2,18 +2,7 @@ const csvFuncs = {};
 
 // returns array of objects, each object is a row with key = column name and value = value in cell
 csvFuncs.getAllRows = async () => {
-  console.log('Called getAllRows in mock csvFuncs');
-  // return new Promise((resolve, reject) => {
-  //   console.log('Inside mock promise within mockGetAllRows');
-  //   const resultArray = [1, 2, 3];
-  //   process.nextTick(() => {
-  //     console.log('Inside mock resolving promise');
-  //     resolve[resultArray];
-  //   });
-  // });
-
   return Promise.resolve([1, 2, 3]);
-
 };
 
 /**

--- a/server/controllers/__mocks__/csvFuncs.js
+++ b/server/controllers/__mocks__/csvFuncs.js
@@ -12,7 +12,7 @@ csvFuncs.getAllRows = async () => {
   //   });
   // });
 
-  return [1, 2, 3];
+  return Promise.resolve([1, 2, 3]);
 
 };
 

--- a/server/controllers/__mocks__/csvFuncs.js
+++ b/server/controllers/__mocks__/csvFuncs.js
@@ -1,0 +1,50 @@
+const csvFuncs = {};
+
+// returns array of objects, each object is a row with key = column name and value = value in cell
+csvFuncs.getAllRows = async (fileName) => {
+  
+}
+
+/**
+ *
+ * Given a function id, startdate string and enddate string, returns number of runs in that period
+ *
+ * @param {number} funcID : number
+ * @param {number} startDate : the time in miliseconds that represents start of period of calculation
+ * @param {number} endDate : the time in miliseconds that represents end of period of calculation
+ */
+csvFuncs.getTotalRuns = (arr, funcId, startDate, endDate) => {
+
+}
+
+/**
+ *
+ * Given an array of rows, return the number of rows that are between the specified dates, of the specified function and are cold/warm
+ *
+ * @param {rows[]} arr - array of rows
+ * @param {number} funcID - function you would like to get a total for
+ * @param {boolean} value - if looking for cold (true) or warm starts (false)
+ * @param {number} startDate - start time of the period in milliseconds
+ * @param {number} endDate - end time of the period in milliseconds
+ * @returns {number} - number of rows that match the above conditions
+ */
+csvFuncs.getCold = (arr, funcID, value, startDate, endDate) => {
+
+}
+
+/**
+ * Given a start/end date, give the total of a specified column filtered by pings which are either cold or warm starts.
+ *
+ * @param {rows[]} arr - array of rows
+ * @param {number} funcID - number uniquely identifying a particular function
+ * @param {string} avColumn - the that the user would like to have totalled
+ * @param {number} startDate - start time of the period in milliseconds
+ * @param {number} endDate - end time of the period in milliseconds
+ * @param {boolean} cold - If you want the function to be looking at coldstarts or warm (defaults to warm)
+ * @returns A number representing the total of AvColumn between the given dates filtered on cold status passed in (defaulting to true)
+ */
+csvFuncs.getSum = (arr, funcID, avColumn, startDate, endDate, cold = false) => {
+
+}
+
+module.exports = csvFuncs;

--- a/server/controllers/__mocks__/csvFuncs.js
+++ b/server/controllers/__mocks__/csvFuncs.js
@@ -1,50 +1,39 @@
 const csvFuncs = {};
 
 // returns array of objects, each object is a row with key = column name and value = value in cell
-csvFuncs.getAllRows = async (fileName) => {
-  
-}
+csvFuncs.getAllRows = async () => {
+  console.log('Called getAllRows in mock csvFuncs');
+  return new Promise((resolve, reject) => {
+    console.log('Inside mock promise within mockGetAllRows');
+    const resultArray = [1, 2, 3];
+    process.nextTick(() => {
+      console.log('Inside mock resolving promise');
+      resolve[resultArray];
+    });
+  });
+};
 
 /**
  *
- * Given a function id, startdate string and enddate string, returns number of runs in that period
- *
- * @param {number} funcID : number
- * @param {number} startDate : the time in miliseconds that represents start of period of calculation
- * @param {number} endDate : the time in miliseconds that represents end of period of calculation
+ * Pretend there are 10 total functions
  */
 csvFuncs.getTotalRuns = (arr, funcId, startDate, endDate) => {
-
-}
+  return 10;
+};
 
 /**
  *
- * Given an array of rows, return the number of rows that are between the specified dates, of the specified function and are cold/warm
- *
- * @param {rows[]} arr - array of rows
- * @param {number} funcID - function you would like to get a total for
- * @param {boolean} value - if looking for cold (true) or warm starts (false)
- * @param {number} startDate - start time of the period in milliseconds
- * @param {number} endDate - end time of the period in milliseconds
- * @returns {number} - number of rows that match the above conditions
+ * Mocking that 5 functions are cold
  */
 csvFuncs.getCold = (arr, funcID, value, startDate, endDate) => {
-
-}
+  return 5;
+};
 
 /**
- * Given a start/end date, give the total of a specified column filtered by pings which are either cold or warm starts.
- *
- * @param {rows[]} arr - array of rows
- * @param {number} funcID - number uniquely identifying a particular function
- * @param {string} avColumn - the that the user would like to have totalled
- * @param {number} startDate - start time of the period in milliseconds
- * @param {number} endDate - end time of the period in milliseconds
- * @param {boolean} cold - If you want the function to be looking at coldstarts or warm (defaults to warm)
- * @returns A number representing the total of AvColumn between the given dates filtered on cold status passed in (defaulting to true)
+ * If we're looking at cold functions, they have 200ms average latency, but warm ones have 100 average latency)
  */
 csvFuncs.getSum = (arr, funcID, avColumn, startDate, endDate, cold = false) => {
-
-}
+  return cold ? 5 * 200 : 5 * 100;
+};
 
 module.exports = csvFuncs;

--- a/server/controllers/__mocks__/csvFuncs.js
+++ b/server/controllers/__mocks__/csvFuncs.js
@@ -3,14 +3,17 @@ const csvFuncs = {};
 // returns array of objects, each object is a row with key = column name and value = value in cell
 csvFuncs.getAllRows = async () => {
   console.log('Called getAllRows in mock csvFuncs');
-  return new Promise((resolve, reject) => {
-    console.log('Inside mock promise within mockGetAllRows');
-    const resultArray = [1, 2, 3];
-    process.nextTick(() => {
-      console.log('Inside mock resolving promise');
-      resolve[resultArray];
-    });
-  });
+  // return new Promise((resolve, reject) => {
+  //   console.log('Inside mock promise within mockGetAllRows');
+  //   const resultArray = [1, 2, 3];
+  //   process.nextTick(() => {
+  //     console.log('Inside mock resolving promise');
+  //     resolve[resultArray];
+  //   });
+  // });
+
+  return [1, 2, 3];
+
 };
 
 /**

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -32,7 +32,16 @@ dataController.getData = async (req, res, next) => {
   }
 };
 
-// middleware that gets number of runs for each function using all data available
+/**
+ *
+ * middleware that gets number of runs for each function using all data available
+ * This middleware controlls a lot of the core calculations being used by the front-end.
+ *
+ * @param {*} req express request object
+ * @param {*} res express response object
+ * @param {*} next express next object
+ * @returns
+ */
 dataController.getRuns = async (req, res, next) => {
   try {
     // get array of all the functions from previous middleware
@@ -40,86 +49,134 @@ dataController.getRuns = async (req, res, next) => {
 
     /* NOTE HERE ------------- get period of calculation (day, week, all data) from queryparams HARDCODED FOR NOW - TO DISCUSS WITH STEPHEN
     if one day period = 1, if one week period = 7, if all data available, period = Date.now()/86400000 --------------------*/
-    const period = 7;
+    // NOTE: GRABBING TWO WEEKS OF DATA SO I DONT FILTER OUT ALL RESULTS
+    const period = 14;
     //change period to milliseconds
     const periodMS = period * 86400000;
     // calculate startDate as current date minus the period we are covering in milliseconds
     const startDate = Date.now() - new Date(periodMS);
-    // console.log("start date", startDate)
     const endDate = Date.now();
 
+    // Set res.locals.all to the record of all rows in the csv
     const data = await csvFuncs.getAllRows(datafileName);
-    const totalRuns = [];
-    // for each function in the user file, calculate the number of runs between two specified dates (end date is alws now, and start date can be 1 day ago, 7 days ago or 0 for all data available)
-    records.forEach((row) => {
-      // count tracks number of runs for each function in specified date
-      let count = csvFuncs.getTotalRuns(data, row.funcID, startDate, endDate);
-      // count cold tracks the number of runs for each function where 'cold' is true
-      let countCold = csvFuncs.getCold(
-        data,
-        row.funcID,
-        'true',
-        startDate,
-        endDate
-      );
+    res.locals.all = data;
 
-      // sumLat calculates the sum of the latency for each function
-      let sumLat = csvFuncs.getSum(
-        data,
-        row.funcID,
-        'serverDifference',
-        startDate,
-        endDate,
-        false
-      );
-      let avWarmLat =
-        csvFuncs.getSum(
-          data,
-          row.funcID,
-          'serverDifference',
-          startDate,
-          endDate,
-          false
-        ) /
-        (count - countCold);
-      let avColdLat =
-        csvFuncs.getSum(
-          data,
-          row.funcID,
-          'serverDifference',
-          startDate,
-          endDate,
-          'true'
-        ) / countCold;
+    // declare FuncStatsCreator that accepts a funcId and funcName, we'll us this to keep track of calculated stats
+    class FuncStatsCreator {
+      constructor(funcID, funcName) {
+        this.id = funcID;
+        this.name = funcName;
+        this.totalStarts = 0;
+        this.coldStarts = 0;
+        this.totalLatency = 0;
+        this.coldTotalLatency = 0;
 
-      // percCold is the average number of cold starts and avLat is the average latency
-      let percCold = 0;
-      let avLat = 0;
-
-      if (count !== 0) {
-        percCold = countCold / count;
-        avLat = sumLat / count;
+        // These are stats that will eventually need to be calculated
+        this.percentCold;
+        this.aveLatency;
+        this.coldLatency;
+        this.warmLatency;
+        this.coldToWarm;
       }
 
-      // push all calculated values into the totalRuns array with additional infoprmation about the current function
-      totalRuns.push({
-        id: row.funcID,
-        name: row.funcName,
-        totalRuns: count,
-        coldStarts: countCold,
-        percentCold: percCold,
-        aveLatency: avLat,
-        coldLatency: avColdLat ? avColdLat : 0,
-        warmLatency: avWarmLat ? avWarmLat : 0,
-        coldToWarm: avColdLat / avWarmLat ? avColdLat / avWarmLat : 0,
-      }); // for funcid= 1 [{id: 1, name: testfuncforApp1, totalRuns=count=10, numberRun:xx, numWarm }]
+      /**
+       * Helper function that will adjust properties based on if the current row is cold, and the current row's serverDifference
+       */
+      addRecord(cold, serverDifference) {
+        // Add to the totals
+        this.totalStarts++;
+        this.totalLatency = this.totalLatency + serverDifference;
+        // If its cold, add to the cold properties, we'll calculate warm later
+        if (cold) {
+          this.coldStarts++;
+          this.coldTotalLatency = this.coldTotalLatency + serverDifference;
+        }
+      }
+
+      /**
+       * If the calculations are valid, will populate the eventual stats required
+       * @returns undefined, just used to break
+       */
+      calculateStats() {
+        // Avoid divide by zero
+        if (this.totalStarts < 1) return;
+
+        this.percentCold = this.coldStarts / this.totalStarts;
+        this.aveLatency = this.totalLatency / this.totalStarts;
+
+        // Ensure we have cold starts before calc
+        if (this.coldStarts > 0) {
+          this.coldLatency = this.coldTotalLatency / this.coldStarts;
+        }
+
+        // Ensure we have warm starts before calc
+        if (this.totalStarts - this.coldStarts > 0) {
+          this.warmLatency =
+            (this.totalLatency - this.coldTotalLatency) /
+            (this.totalStarts - this.coldStarts);
+        }
+
+        // Ensure we have both cold and warm latency before calc
+        if (this.coldLatency > 0 && this.warmLatency > 0) {
+          this.coldToWarm = this.coldLatency / this.warmLatency;
+        }
+      }
+    }
+
+    // Create an object that will let us aggregate stats on each function
+    // key is the current funcId, value is a new FuncStatsCreator(funcId, funcName)
+    const aggregator = {};
+    records.forEach((record) => {
+      aggregator[record.funcID] = new FuncStatsCreator(
+        record.funcID,
+        record.funcName
+      );
     });
 
-    // calculate totals and averages for all the functions in totalRuns
+    console.log('Built aggregator, ', aggregator);
+
+    // Process each row of data
+    data.forEach((row) => {
+      // Check that row.invokeTime is within startDate and endDate & is a function we're looking for
+      if (
+        row.invokeTime >= startDate &&
+        row.invokeTime <= endDate &&
+        Object.hasOwn(aggregator, row.funcID)
+      ) {
+        aggregator[row.funcID].addRecord(
+          !!row.cold,
+          Number(row.serverDifference)
+        );
+      }
+    });
+
+    // declare the resulting array which we will return
+    const totalRuns = [];
+
+    // Tell all of the aggregator objects to calculate their stats, then push a new object to the totalRuns array
+    for (const funcStat in aggregator) {
+      aggregator[funcStat].calculateStats();
+
+      const funcObject = {};
+      funcObject.id = aggregator[funcStat].id;
+      funcObject.name = aggregator[funcStat].name;
+      funcObject.totalRuns = aggregator[funcStat].totalStarts;
+      funcObject.coldStarts = aggregator[funcStat].coldStarts;
+      funcObject.percentCold = aggregator[funcStat].percentCold;
+      funcObject.aveLatency = aggregator[funcStat].aveLatency;
+      funcObject.coldLatency = aggregator[funcStat].coldLatency;
+      funcObject.warmLatency = aggregator[funcStat].warmLatency;
+      funcObject.coldToWarm = aggregator[funcStat].coldToWarm;
+
+      totalRuns.push(funcObject);
+    }
+
+    console.log('And now totalRuns is: ', totalRuns);
 
     res.locals.runs = totalRuns;
-    res.locals.all = data;
-    // console.log(res.locals.runs);
+
+    // console.log('Finished getData, runs is: ', totalRuns);
+
     return next();
   } catch (err) {
     return next({

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -183,6 +183,7 @@ dataController.getRuns = async (req, res, next) => {
 
     res.locals.runs = totalRuns;
 
+    // Uncomment to re-benchmark timing
     console.log('Finished run, data is: ', {
       fullRunInterval: createdResults - enterGetRun,
       grabAllRowsInterval: grabbedAllRows - enterGetRun,

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -44,6 +44,7 @@ dataController.getData = async (req, res, next) => {
  */
 dataController.getRuns = async (req, res, next) => {
   try {
+    const enterGetRun = Date.now();
     // get array of all the functions from previous middleware
     const { records } = res.locals;
 
@@ -59,6 +60,9 @@ dataController.getRuns = async (req, res, next) => {
 
     // Set res.locals.all to the record of all rows in the csv
     const data = await csvFuncs.getAllRows(datafileName);
+
+    const grabbedAllRows = Date.now();
+
     res.locals.all = data;
 
     // declare FuncStatsCreator that accepts a funcId and funcName, we'll us this to keep track of calculated stats
@@ -133,6 +137,8 @@ dataController.getRuns = async (req, res, next) => {
       );
     });
 
+    const builtAggregator = Date.now();
+
     // Process each row of data
     data.forEach((row) => {
       // Check that row.invokeTime is within startDate and endDate & is a function we're looking for
@@ -147,6 +153,8 @@ dataController.getRuns = async (req, res, next) => {
         );
       }
     });
+
+    const processsedRecords = Date.now();
 
     // declare the resulting array which we will return
     const totalRuns = [];
@@ -169,9 +177,17 @@ dataController.getRuns = async (req, res, next) => {
       totalRuns.push(funcObject);
     }
 
+    const createdResults = Date.now();
+
     res.locals.runs = totalRuns;
 
-    // console.log('Finished getData, runs is: ', totalRuns);
+    console.log('Finished run, data is: ', {
+      fullRunInterval: createdResults - enterGetRun,
+      grabAllRowsInterval: grabbedAllRows - enterGetRun,
+      builtAggregatorInterval: builtAggregator - grabbedAllRows,
+      processedRecordsInterval: processsedRecords - builtAggregator,
+      createdResultsInterval: createdResults - processsedRecords,
+    });
 
     return next();
   } catch (err) {

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -47,7 +47,9 @@ dataController.getRuns = async (req, res, next) => {
     // console.log("start date", startDate)
     const endDate = Date.now();
 
+    console.log('Inside getRuns setting data');
     const data = await csvFuncs.getAllRows(datafileName);
+    console.log('Inside getRuns set data to: ', data);
     const totalRuns = [];
     // for each function in the user file, calculate the number of runs between two specified dates (end date is alws now, and start date can be 1 day ago, 7 days ago or 0 for all data available)
     records.forEach((row) => {
@@ -116,9 +118,13 @@ dataController.getRuns = async (req, res, next) => {
 
     // calculate totals and averages for all the functions in totalRuns
 
+    console.log('Inside dataController setting res.locals');
+    console.log('Res object is: ', res);
     res.locals.runs = totalRuns;
     res.locals.all = data;
-    // console.log(res.locals.runs);
+    console.log('Function sets res.locals.all at ', Date.now());
+    console.log('Inside dataController set res.locals');
+    console.log('Res object is: ', res);
     return next();
   } catch (err) {
     return next({

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -1,4 +1,5 @@
 // require needed modules
+// require needed modules
 const fs = require('fs');
 const parse = require('csv-parser');
 const path = require('path');
@@ -47,9 +48,7 @@ dataController.getRuns = async (req, res, next) => {
     // console.log("start date", startDate)
     const endDate = Date.now();
 
-    console.log('Inside getRuns setting data');
     const data = await csvFuncs.getAllRows(datafileName);
-    console.log('Inside getRuns set data to: ', data);
     const totalRuns = [];
     // for each function in the user file, calculate the number of runs between two specified dates (end date is alws now, and start date can be 1 day ago, 7 days ago or 0 for all data available)
     records.forEach((row) => {
@@ -118,13 +117,9 @@ dataController.getRuns = async (req, res, next) => {
 
     // calculate totals and averages for all the functions in totalRuns
 
-    console.log('Inside dataController setting res.locals');
-    console.log('Res object is: ', res);
     res.locals.runs = totalRuns;
     res.locals.all = data;
-    console.log('Function sets res.locals.all at ', Date.now());
-    console.log('Inside dataController set res.locals');
-    console.log('Res object is: ', res);
+    // console.log(res.locals.runs);
     return next();
   } catch (err) {
     return next({

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -70,7 +70,7 @@ dataController.getRuns = async (req, res, next) => {
       constructor(funcID, funcName) {
         this.id = funcID;
         this.name = funcName;
-        this.totalStarts = 0;
+        this.totalRuns = 0;
         this.coldStarts = 0;
         this.totalLatency = 0;
         this.coldTotalLatency = 0;
@@ -88,10 +88,11 @@ dataController.getRuns = async (req, res, next) => {
        */
       addRecord(cold, serverDifference) {
         // Add to the totals
-        this.totalStarts++;
+        this.totalRuns++;
         this.totalLatency = this.totalLatency + serverDifference;
         // If its cold, add to the cold properties, we'll calculate warm later
         if (cold) {
+
           this.coldStarts++;
           this.coldTotalLatency = this.coldTotalLatency + serverDifference;
         }
@@ -103,10 +104,10 @@ dataController.getRuns = async (req, res, next) => {
        */
       calculateStats() {
         // Avoid divide by zero
-        if (this.totalStarts < 1) return;
+        if (this.totalRuns < 1) return;
 
-        this.percentCold = this.coldStarts / this.totalStarts;
-        this.aveLatency = this.totalLatency / this.totalStarts;
+        this.percentCold = this.coldStarts / this.totalRuns;
+        this.aveLatency = this.totalLatency / this.totalRuns;
 
         // Ensure we have cold starts before calc
         if (this.coldStarts > 0) {
@@ -114,10 +115,10 @@ dataController.getRuns = async (req, res, next) => {
         }
 
         // Ensure we have warm starts before calc
-        if (this.totalStarts - this.coldStarts > 0) {
+        if (this.totalRuns - this.coldStarts > 0) {
           this.warmLatency =
             (this.totalLatency - this.coldTotalLatency) /
-            (this.totalStarts - this.coldStarts);
+            (this.totalRuns - this.coldStarts);
         }
 
         // Ensure we have both cold and warm latency before calc
@@ -148,7 +149,7 @@ dataController.getRuns = async (req, res, next) => {
         Object.hasOwn(aggregator, row.funcID)
       ) {
         aggregator[row.funcID].addRecord(
-          !!row.cold,
+          row.cold === 'true' ? true : false,
           Number(row.serverDifference)
         );
       }
@@ -166,7 +167,7 @@ dataController.getRuns = async (req, res, next) => {
       const funcObject = {};
       funcObject.id = aggregator[funcStat].id;
       funcObject.name = aggregator[funcStat].name;
-      funcObject.totalRuns = aggregator[funcStat].totalStarts;
+      funcObject.totalRuns = aggregator[funcStat].totalRuns;
       funcObject.coldStarts = aggregator[funcStat].coldStarts;
       funcObject.percentCold = aggregator[funcStat].percentCold;
       funcObject.aveLatency = aggregator[funcStat].aveLatency;

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -63,7 +63,8 @@ dataController.getRuns = async (req, res, next) => {
 
     const grabbedAllRows = Date.now();
 
-    res.locals.all = data;
+    // Sending only the last 25 records (a bit more than the front end needs, just in case, but less than the whole file).
+    res.locals.all = data.slice(data.length - 25);
 
     // declare FuncStatsCreator that accepts a funcId and funcName, we'll us this to keep track of calculated stats
     class FuncStatsCreator {

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -73,11 +73,11 @@ dataController.getRuns = async (req, res, next) => {
         this.coldTotalLatency = 0;
 
         // These are stats that will eventually need to be calculated
-        this.percentCold;
-        this.aveLatency;
-        this.coldLatency;
-        this.warmLatency;
-        this.coldToWarm;
+        this.percentCold = 0;
+        this.aveLatency = 0;
+        this.coldLatency = 0;
+        this.warmLatency = 0;
+        this.coldToWarm = 0;
       }
 
       /**

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -44,7 +44,6 @@ dataController.getData = async (req, res, next) => {
  */
 dataController.getRuns = async (req, res, next) => {
   try {
-    const enterGetRun = Date.now();
     // get array of all the functions from previous middleware
     const { records } = res.locals;
 
@@ -60,8 +59,6 @@ dataController.getRuns = async (req, res, next) => {
 
     // Set res.locals.all to the record of all rows in the csv
     const data = await csvFuncs.getAllRows(datafileName);
-
-    const grabbedAllRows = Date.now();
 
     // Sending only the last 25 records (a bit more than the front end needs, just in case, but less than the whole file).
     res.locals.all = data.slice(data.length - 25);
@@ -139,8 +136,6 @@ dataController.getRuns = async (req, res, next) => {
       );
     });
 
-    const builtAggregator = Date.now();
-
     // Process each row of data
     data.forEach((row) => {
       // Check that row.invokeTime is within startDate and endDate & is a function we're looking for
@@ -155,8 +150,6 @@ dataController.getRuns = async (req, res, next) => {
         );
       }
     });
-
-    const processsedRecords = Date.now();
 
     // declare the resulting array which we will return
     const totalRuns = [];
@@ -179,18 +172,7 @@ dataController.getRuns = async (req, res, next) => {
       totalRuns.push(funcObject);
     }
 
-    const createdResults = Date.now();
-
     res.locals.runs = totalRuns;
-
-    // Uncomment to re-benchmark timing
-    console.log('Finished run, data is: ', {
-      fullRunInterval: createdResults - enterGetRun,
-      grabAllRowsInterval: grabbedAllRows - enterGetRun,
-      builtAggregatorInterval: builtAggregator - grabbedAllRows,
-      processedRecordsInterval: processsedRecords - builtAggregator,
-      createdResultsInterval: createdResults - processsedRecords,
-    });
 
     return next();
   } catch (err) {

--- a/server/controllers/dataController.js
+++ b/server/controllers/dataController.js
@@ -133,8 +133,6 @@ dataController.getRuns = async (req, res, next) => {
       );
     });
 
-    console.log('Built aggregator, ', aggregator);
-
     // Process each row of data
     data.forEach((row) => {
       // Check that row.invokeTime is within startDate and endDate & is a function we're looking for
@@ -170,8 +168,6 @@ dataController.getRuns = async (req, res, next) => {
 
       totalRuns.push(funcObject);
     }
-
-    console.log('And now totalRuns is: ', totalRuns);
 
     res.locals.runs = totalRuns;
 

--- a/server/server.js
+++ b/server/server.js
@@ -43,11 +43,12 @@ app.use((err, req, res, next) => {
   return res.status(errorObj.status).json(errorObj.message);
 });
 
-// initializeJobsOnce()
+initializeJobsOnce()
 
 // set up listener
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`server listening on port ${PORT}: http://localhost:${PORT}/`);
 });
 
 module.exports = app;
+module.exports = server;

--- a/server/server.js
+++ b/server/server.js
@@ -50,4 +50,4 @@ app.listen(PORT, () => {
   console.log(`server listening on port ${PORT}: http://localhost:${PORT}/`);
 });
 
-module.export = app;
+module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -43,7 +43,7 @@ app.use((err, req, res, next) => {
   return res.status(errorObj.status).json(errorObj.message);
 });
 
-initializeJobsOnce()
+// initializeJobsOnce()
 
 
 

--- a/src/sum.js
+++ b/src/sum.js
@@ -1,4 +1,0 @@
-function sum(a, b) {
-  return a + b;
-}
-module.exports = sum;


### PR DESCRIPTION
1. Refactored getRuns so an end to end request to `data` runs -68.5% faster (see working log in issue #68).

2. Added several testing files and configured them to run correctly:
- `__tests__/dataController.test.js` - Initial testing for the getRuns unit testing (relies upon an also added mocked version of `csvFuncs.js`)
- `__tests__/csvReadingTiming.test.js` - Records how long it takes to read data from `data.csv`
- `__tests__/dataControllerTiming.test.js` - Records timing for how long the end-to-end responses take using supertest (which is installed and edits `package*.json` files
- Deleted the `sum.js` file and its associated tests which were used to validate Jest installation.

These changes also included some slight refactoring of `server/server.js`. The app object was not being correctly exported (needed to read `module.exports = app;` and saved the response of calling `app.listen()` to another variable and exported this, which allows Jest to more elegantly close a connection and not have hanging threads when executing end-to-end route testing.